### PR TITLE
VIEW3D の機能調整(前半；アーマチュアからポーズ関連まで)：完了

### DIFF
--- a/RENDER_PT_render.py
+++ b/RENDER_PT_render.py
@@ -4,7 +4,6 @@
 import bpy
 from bpy.props import *
 import sys, subprocess
-from bpy.app.handlers import persistent
 
 ################
 # オペレーター #
@@ -50,12 +49,6 @@ class RenderBackground(bpy.types.Operator):
 	def invoke(self, context, event):
 		return context.window_manager.invoke_props_dialog(self)
 
-
-#context.preferences.view.render_display_typeの初期値を IMAGE →　WIONDOW
-@persistent
-def setIt(context):
-	bpy.context.preferences.view.render_display_type = "WINDOW"	
-
 ################
 # クラスの登録 #
 ################
@@ -68,14 +61,10 @@ classes = [
 def register():
 	for cls in classes:
 		bpy.utils.register_class(cls)
-	bpy.app.handlers.depsgraph_update_pre.append(setIt)
-	bpy.app.handlers.load_post.append(setIt)
 
 def unregister():
 	for cls in classes:
 		bpy.utils.unregister_class(cls)
-	bpy.app.handlers.depsgraph_update_pre.remove(setIt)
-	bpy.app.handlers.load_post.remove(setIt)
 
 
 ################

--- a/VIEW3D_MT_bone_options_toggle.py
+++ b/VIEW3D_MT_bone_options_toggle.py
@@ -44,10 +44,16 @@ class SetCurvedBones(bpy.types.Operator):
 	def execute(self, context):
 		obj = bpy.context.active_object
 		if (obj.type == "ARMATURE"):
-			for bone in context.selected_pose_bones:
-				obj.data.bones[bone.name].bbone_segments = self.bbone_segments
-				obj.data.bones[bone.name].bbone_in = self.bbone_in
-				obj.data.bones[bone.name].bbone_out = self.bbone_out
+			if (obj.mode == "EDIT"):
+				for bone in context.selected_bones:
+					bone.bbone_segments = self.bbone_segments
+					bone.bbone_easein = self.bbone_in
+					bone.bbone_easeout = self.bbone_out
+			elif (obj.mode == "POSE"):
+				for bone in context.selected_pose_bones:
+					obj.pose.bones[bone.name].bone.bbone_segments = self.bbone_segments
+					obj.pose.bones[bone.name].bbone_easein = self.bbone_in
+					obj.pose.bones[bone.name].bbone_easeout = self.bbone_out
 		return {'FINISHED'}
 
 class SetBoneRoll(bpy.types.Operator):

--- a/VIEW3D_MT_edit_mesh.py
+++ b/VIEW3D_MT_edit_mesh.py
@@ -57,10 +57,11 @@ class ProportionalPieOperator(bpy.types.Operator):
 	bl_options = {'REGISTER'}
 
 	def execute(self, context):
-		if (context.scene.tool_settings.proportional_edit == "DISABLED"):
+		if (not context.scene.tool_settings.use_proportional_edit):
+			#context.scene.tool_settings.use_proportional_edit = True
 			bpy.ops.wm.call_menu_pie(name=ProportionalPie.bl_idname)
 		else:
-			context.scene.tool_settings.proportional_edit = "DISABLED"
+			bpy.ops.wm.call_menu_pie(name=ProportionalPie.bl_idname)
 		return {'FINISHED'}
 class ProportionalPie(bpy.types.Menu): #
 	bl_idname = "VIEW3D_MT_edit_mesh_pie_proportional"
@@ -71,6 +72,7 @@ class ProportionalPie(bpy.types.Menu): #
 		self.layout.menu_pie().operator(SetProportionalEdit.bl_idname, text="Enable", icon="PROP_ON").mode = "ENABLED"
 		self.layout.menu_pie().operator(SetProportionalEdit.bl_idname, text="Projection (2D)", icon="PROP_ON").mode = "PROJECTED"
 		self.layout.menu_pie().operator(SetProportionalEdit.bl_idname, text="Connection", icon="PROP_CON").mode = "CONNECTED"
+		self.layout.menu_pie().operator(SetProportionalEdit.bl_idname, text="Disable", icon="PROP_OFF").mode = "DISABLED"
 class SetProportionalEdit(bpy.types.Operator): #
 	bl_idname = "mesh.set_proportional_edit"
 	bl_label = "Set proportional edit mode"
@@ -80,7 +82,21 @@ class SetProportionalEdit(bpy.types.Operator): #
 	mode : StringProperty(name="Mode", default="DISABLED")
 
 	def execute(self, context):
-		context.scene.tool_settings.proportional_edit = self.mode
+		settings = context.scene.tool_settings
+		if self.mode == "ENABLED":
+			settings.use_proportional_edit = True
+			settings.use_proportional_projected = False
+			settings.use_proportional_connected = False
+		elif self.mode == "PROJECTED":
+			settings.use_proportional_edit = True
+			settings.use_proportional_projected = not settings.use_proportional_projected
+		elif self.mode == "CONNECTED":
+			settings.use_proportional_edit = True
+			settings.use_proportional_connected = not settings.use_proportional_connected
+		else:
+			settings.use_proportional_edit = False
+			settings.use_proportional_projected = False
+			settings.use_proportional_connected = False
 		return {'FINISHED'}
 
 ################

--- a/VIEW3D_MT_edit_mesh_showhide.py
+++ b/VIEW3D_MT_edit_mesh_showhide.py
@@ -2,6 +2,7 @@
 # "3D View" Area > "Mesh Editor" Mode > "Mesh" Menu > "Show/Hide" Menu
 
 import bpy
+import bmesh
 from bpy.props import *
 
 ################
@@ -68,12 +69,21 @@ class HideParts(bpy.types.Operator):
 	unselected : BoolProperty(name="Non-select Parts", default=False)
 
 	def execute(self, context):
+		for bol, mode in zip(context.tool_settings.mesh_select_mode, ["VERT","EDGE","FACE"]):
+			if bol:
+				mode_type = mode
 		isSelecteds = []
-		for vert in context.active_object.data.vertices:
+		mesh = bmesh.from_edit_mesh(context.active_object.data)
+		for vert in mesh.verts:
 			isSelecteds.append(vert.select)
-		bpy.ops.mesh.select_linked(limit=False)
+		bpy.ops.mesh.select_linked()
 		bpy.ops.mesh.hide(unselected=self.unselected)
 		bpy.ops.mesh.select_all(action='DESELECT')
+		if self.unselected:
+			for idx, vert in enumerate(mesh.verts):
+				vert.select = isSelecteds[idx]
+		bpy.ops.mesh.select_mode(use_extend=False, use_expand=False, type='VERT')
+		bpy.ops.mesh.select_mode(use_extend=False, use_expand=False, type=mode_type)
 		return {'FINISHED'}
 
 ################

--- a/VIEW3D_MT_edit_mesh_specials.py
+++ b/VIEW3D_MT_edit_mesh_specials.py
@@ -19,12 +19,14 @@ class PaintSelectedVertexColor(bpy.types.Operator):
 	def execute(self, context):
 		activeObj = context.active_object
 		me = activeObj.data
+		if not me.vertex_colors.active:
+			me.vertex_colors.active = me.vertex_colors.new()
 		bpy.ops.object.mode_set(mode='OBJECT')
 		i = 0
 		for poly in me.polygons:
 			for vert in poly.vertices:
 				if (me.vertices[vert].select):
-					me.vertex_colors.active.data[i].color = self.color
+					me.vertex_colors.active.data[i].color = (self.color[0], self.color[1], self.color[2], 1.0)
 				i += 1
 		bpy.ops.object.mode_set(mode='EDIT')
 		return {'FINISHED'}
@@ -104,9 +106,7 @@ class ToggleMirrorModifier(bpy.types.Operator):
 					activeObj.modifiers.remove(mod)
 		else:
 			new_mod = activeObj.modifiers.new("Mirror", 'MIRROR')
-			new_mod.use_x = self.use_x
-			new_mod.use_y = self.use_y
-			new_mod.use_z = self.use_z
+			new_mod.use_axis = [self.use_x, self.use_y, self.use_z]
 			new_mod.use_mirror_merge = self.use_mirror_merge
 			new_mod.use_clip = self.use_clip
 			new_mod.use_mirror_vertex_groups = self.use_mirror_vertex_groups
@@ -137,6 +137,9 @@ class SelectedVertexGroupAverage(bpy.types.Operator):
 		return context.window_manager.invoke_props_dialog(self)
 	def execute(self, context):
 		obj = context.active_object
+		if len(obj.vertex_groups) == 0:
+			self.report(type={'ERROR'}, message="This object has no vertex_group")
+			return {'CANCELLED'}		
 		if (obj.type == "MESH"):
 			pre_mode = obj.mode
 			bpy.ops.object.mode_set(mode='OBJECT')

--- a/VIEW3D_MT_make_links.py
+++ b/VIEW3D_MT_make_links.py
@@ -42,7 +42,10 @@ class MakeLinkLayer(bpy.types.Operator):
 	def execute(self, context):
 		for obj in context.selected_objects:
 			if (obj.name != context.active_object.name):
-				obj.layers = context.active_object.layers
+				active_col_name = context.active_object.users_collection[0].name
+				active_col_idx  = bpy.data.collection.find(active_col_name)
+				bpy.ops.object.move_to_collection(collection_index=active_col_idx+1)
+				break
 		return {'FINISHED'}
 
 class MakeLinkDisplaySetting(bpy.types.Operator):
@@ -58,9 +61,9 @@ class MakeLinkDisplaySetting(bpy.types.Operator):
 	show_all_edges : BoolProperty(name="Show All Edges", default=True)
 	show_bounds : BoolProperty(name="Bound", default=True)
 	show_texture_space : BoolProperty(name="Texture Space", default=True)
-	show_x_ray : BoolProperty(name="X-ray", default=True)
+	show_in_front : BoolProperty(name="Front", default=True)
 	show_transparent : BoolProperty(name="Alpha", default=True)
-	draw_bounds_type : BoolProperty(name="Bound Type", default=True)
+	display_bounds_type : BoolProperty(name="Bound Type", default=True)
 	display_type : BoolProperty(name="Maximum Draw Type", default=True)
 	color : BoolProperty(name="Object Color", default=True)
 
@@ -86,12 +89,12 @@ class MakeLinkDisplaySetting(bpy.types.Operator):
 						obj.show_bounds = activeObj.show_bounds
 					if (self.show_texture_space):
 						obj.show_texture_space = activeObj.show_texture_space
-					if (self.show_x_ray):
-						obj.show_x_ray = activeObj.show_x_ray
+					if (self.show_in_front):
+						obj.show_in_front = activeObj.show_in_front
 					if (self.show_transparent):
 						obj.show_transparent = activeObj.show_transparent
-					if (self.draw_bounds_type):
-						obj.draw_bounds_type = activeObj.draw_bounds_type
+					if (self.display_bounds_type):
+						obj.display_bounds_type = activeObj.display_bounds_type
 					if (self.display_type):
 						obj.display_type = activeObj.display_type
 					if (self.color):
@@ -125,7 +128,7 @@ class MakeLinkUVNames(bpy.types.Operator):
 				target_objs.append(obj)
 		for obj in target_objs:
 			for uv in active_obj.data.uv_layers:
-				obj.data.uv_layers.new(uv.name)
+				obj.data.uv_layers.new(name=uv.name)
 		return {'FINISHED'}
 
 class MakeLinkArmaturePose(bpy.types.Operator):
@@ -133,6 +136,8 @@ class MakeLinkArmaturePose(bpy.types.Operator):
 	bl_label = "Link motion of armature"
 	bl_description = "By constraints on other selected armature mimic active armature movement"
 	bl_options = {'REGISTER', 'UNDO'}
+
+	influence : FloatProperty(name="Influence", default=1.0, max=1.0, min=0.0)
 
 	@classmethod
 	def poll(cls, context):
@@ -163,6 +168,7 @@ class MakeLinkArmaturePose(bpy.types.Operator):
 				const = consts.new('COPY_TRANSFORMS')
 				const.target = active_obj
 				const.subtarget = bone.name
+				const.influence = self.influence
 		return {'FINISHED'}
 
 ######################

--- a/VIEW3D_MT_object.py
+++ b/VIEW3D_MT_object.py
@@ -8,6 +8,56 @@ from bpy.props import *
 # パイメニュー #
 ################
 
+class ApplyModifiersAndJoinObj(bpy.types.Operator):
+	bl_idname = "object.apply_modifiers_and_join_object"
+	bl_label = "Apply modifiers + join"
+	bl_description = "integration from object\'s modifiers to apply all"
+	bl_options = {'REGISTER', 'UNDO'}
+
+	unapply_subsurf : BoolProperty(name="Except Subsurf", default=True)
+	unapply_armature : BoolProperty(name="Except Armature", default=True)
+	unapply_mirror : BoolProperty(name="Except Mirror", default=False)
+
+	@classmethod
+	def poll(cls, context):
+		if 2 <= len(context.selected_objects):
+			return True
+		return False
+
+	def execute(self, context):
+		pre_active_object = context.active_object
+		for obj in context.selected_objects:
+			bpy.context.view_layer.objects.active = obj
+			for mod in obj.modifiers[:]:
+				if self.unapply_subsurf and mod.type == 'SUBSURF':
+					continue
+				if self.unapply_armature and mod.type == 'ARMATURE':
+					continue
+				if self.unapply_mirror and mod.type == 'MIRROR':
+					continue
+				bpy.ops.object.modifier_apply(modifier=mod.name)
+		bpy.context.view_layer.objects.active = pre_active_object
+		bpy.ops.object.join()
+		return {'FINISHED'}
+
+class CopyObjectNameObj(bpy.types.Operator):
+	bl_idname = "object.copy_object_name_object"
+	bl_label = "Copy Object Name"
+	bl_description = "Copy to Clipboard object name"
+	bl_options = {'REGISTER'}
+	
+	@classmethod
+	def poll(cls, context):
+		if (not context.object):
+			return False
+		if (context.window_manager.clipboard == context.object.name):
+			return False
+		return True
+	def execute(self, context):
+		context.window_manager.clipboard = context.object.name
+		self.report(type={'INFO'}, message=context.object.name)
+		return {'FINISHED'}
+
 class CopyPieOperator(bpy.types.Operator):
 	bl_idname = "object.copy_pie_operator"
 	bl_label = "Copy"
@@ -169,6 +219,8 @@ class ShortcutMenu(bpy.types.Menu):
 ################
 
 classes = [
+	ApplyModifiersAndJoinObj,
+	CopyObjectNameObj,
 	CopyPieOperator,
 	CopyPie,
 	ObjectModePieOperator,

--- a/VIEW3D_MT_object.py
+++ b/VIEW3D_MT_object.py
@@ -3,61 +3,11 @@
 
 import bpy, bmesh
 from bpy.props import *
+from . import DATA_PT_modifiers, OBJECT_PT_context_object
 
 ################
 # パイメニュー #
 ################
-
-class ApplyModifiersAndJoinObj(bpy.types.Operator):
-	bl_idname = "object.apply_modifiers_and_join_object"
-	bl_label = "Apply modifiers + join"
-	bl_description = "integration from object\'s modifiers to apply all"
-	bl_options = {'REGISTER', 'UNDO'}
-
-	unapply_subsurf : BoolProperty(name="Except Subsurf", default=True)
-	unapply_armature : BoolProperty(name="Except Armature", default=True)
-	unapply_mirror : BoolProperty(name="Except Mirror", default=False)
-
-	@classmethod
-	def poll(cls, context):
-		if 2 <= len(context.selected_objects):
-			return True
-		return False
-
-	def execute(self, context):
-		pre_active_object = context.active_object
-		for obj in context.selected_objects:
-			bpy.context.view_layer.objects.active = obj
-			for mod in obj.modifiers[:]:
-				if self.unapply_subsurf and mod.type == 'SUBSURF':
-					continue
-				if self.unapply_armature and mod.type == 'ARMATURE':
-					continue
-				if self.unapply_mirror and mod.type == 'MIRROR':
-					continue
-				bpy.ops.object.modifier_apply(modifier=mod.name)
-		bpy.context.view_layer.objects.active = pre_active_object
-		bpy.ops.object.join()
-		return {'FINISHED'}
-
-class CopyObjectNameObj(bpy.types.Operator):
-	bl_idname = "object.copy_object_name_object"
-	bl_label = "Copy Object Name"
-	bl_description = "Copy to Clipboard object name"
-	bl_options = {'REGISTER'}
-	
-	@classmethod
-	def poll(cls, context):
-		if (not context.object):
-			return False
-		if (context.window_manager.clipboard == context.object.name):
-			return False
-		return True
-	def execute(self, context):
-		context.window_manager.clipboard = context.object.name
-		self.report(type={'INFO'}, message=context.object.name)
-		return {'FINISHED'}
-
 class CopyPieOperator(bpy.types.Operator):
 	bl_idname = "object.copy_pie_operator"
 	bl_label = "Copy"
@@ -74,7 +24,7 @@ class CopyPie(bpy.types.Menu):
 
 	def draw(self, context):
 		self.layout.menu_pie().operator("view3d.copybuffer", icon="COPY_ID")
-		self.layout.menu_pie().operator(CopyObjectName.bl_idname, icon="MONKEY")
+		self.layout.menu_pie().operator(OBJECT_PT_context_object.CopyObjectName.bl_idname, icon="MONKEY")
 
 class ObjectModePieOperator(bpy.types.Operator):
 	bl_idname = "object.object_mode_pie_operator"
@@ -212,15 +162,13 @@ class ShortcutMenu(bpy.types.Menu):
 
 	def draw(self, context):
 		self.layout.operator(DeleteUnmassage.bl_idname, icon="PLUGIN")
-		self.layout.operator(ApplyModifiersAndJoin.bl_idname, icon="PLUGIN")
+		self.layout.operator(DATA_PT_modifiers.ApplyModifiersAndJoin.bl_idname, icon="PLUGIN")
 
 ################
 # クラスの登録 #
 ################
 
 classes = [
-	ApplyModifiersAndJoinObj,
-	CopyObjectNameObj,
 	CopyPieOperator,
 	CopyPie,
 	ObjectModePieOperator,

--- a/VIEW3D_MT_object_showhide.py
+++ b/VIEW3D_MT_object_showhide.py
@@ -3,6 +3,7 @@
 
 import bpy
 from bpy.props import *
+import bpy.ops
 
 ################
 # オペレーター #
@@ -14,7 +15,19 @@ class hide_view_clear_unselect(bpy.types.Operator):
 	bl_description = "Does not display objects were hidden again, select"
 	bl_options = {'REGISTER', 'UNDO'}
 
+	show_col : BoolProperty(name="show hided collections", default=False)
+
 	def execute(self, context):
+		master_col = context.view_layer.layer_collection
+		if self.show_col:
+			views = [c for c in master_col.children if not c.exclude and not c.hide_viewport]
+			hides = [c for c in master_col.children if not c.exclude and c.hide_viewport]
+			for col in views:
+				if len(col.children) != 0:
+					views = views + [c for c in col.children if not c.exclude and not c.hide_viewport]
+					hides = hides + [c for c in col.children if not c.exclude and c.hide_viewport]
+			for col in hides:
+				col.hide_viewport = False
 		pre_selectable_objects = []
 		for ob in context.selectable_objects:
 			pre_selectable_objects.append(ob.name)
@@ -30,18 +43,51 @@ class InvertHide(bpy.types.Operator):
 	bl_description = "Flips object\'s view state and non-State"
 	bl_options = {'REGISTER', 'UNDO'}
 
+	invert_nested_col : BoolProperty(name="Invert nested collections\' states", default=False)
+
 	def execute(self, context):
 		objs = []
-		for obj in bpy.data.objects:
-			for i in range(len(bpy.context.scene.layers)):
-				if (bpy.context.scene.layers[i] and obj.layers[i]):
-					for obj2 in objs:
-						if (obj.name == obj2.name):
-							break
-					else:
-						objs.append(obj)
+		hide = []
+		master_col = context.view_layer.layer_collection
+		for obj in master_col.collection.objects:
+			obj.hide_set(not obj.hide_get())
+		collections = [c for c in master_col.children if not c.exclude and not c.hide_viewport]
+		for col in collections:
+			if len(col.children) != 0:
+				collections = collections + [c for c in col.children if not c.exclude and not c.hide_viewport]
+				if self.invert_nested_col:
+					hides = [c for c in col.children if not c.exclude and c.hide_viewport]
+		for col in collections:
+			if col.has_objects():
+				objs = objs + [x for x in col.collection.objects]
 		for obj in objs:
-			obj.hide_set(not obj.hide_get)
+			obj.hide_set(not obj.hide_get())
+		if self.invert_nested_col:
+			for col in hides:
+				col.hide_viewport = False
+		return {'FINISHED'}
+
+class InvertCollectionHide(bpy.types.Operator):
+	bl_idname = "object.invert_collection_hide"
+	bl_label = "Invert Show/Hide (object & collection)"
+	bl_description = "Flips object\'s and collection\'s view state and non-State"
+	bl_options = {'REGISTER', 'UNDO'}
+
+	def execute(self, context):
+		objs = []
+		master_col = context.view_layer.layer_collection
+		for obj in master_col.collection.objects:
+			obj.hide_set(not obj.hide_get())
+		views = [c for c in master_col.children if not c.exclude and not c.hide_viewport]
+		hides = [c for c in master_col.children if not c.exclude and c.hide_viewport]
+		for col in views:
+			if len(col.children) != 0:
+				views = views + [c for c in col.children if not c.exclude and not c.hide_viewport]
+				hides = hides + [c for c in col.children if not c.exclude and c.hide_viewport]
+		for col in views:
+			col.hide_viewport = True
+		for col in hides:
+			col.hide_viewport = False
 		return {'FINISHED'}
 
 class HideOnlyType(bpy.types.Operator):
@@ -105,6 +151,7 @@ class HideExceptType(bpy.types.Operator):
 classes = [
 	hide_view_clear_unselect,
 	InvertHide,
+	InvertCollectionHide,
 	HideOnlyType,
 	HideExceptType
 ]
@@ -136,6 +183,7 @@ def menu(self, context):
 		self.layout.separator()
 		self.layout.operator(hide_view_clear_unselect.bl_idname, icon='PLUGIN')
 		self.layout.operator(InvertHide.bl_idname, icon='PLUGIN')
+		self.layout.operator(InvertCollectionHide.bl_idname, icon='PLUGIN')
 		self.layout.separator()
 		self.layout.operator(HideOnlyType.bl_idname, icon='PLUGIN')
 		self.layout.operator(HideExceptType.bl_idname, icon='PLUGIN')

--- a/VIEW3D_MT_pose_constraints.py
+++ b/VIEW3D_MT_pose_constraints.py
@@ -16,6 +16,7 @@ class ConstraintIKToLimitRotation(bpy.types.Operator):
 
 	isAdd : BoolProperty(name="If not add constraints", default=True)
 	isLocal : BoolProperty(name="Local Space", default=True)
+	DisableSetting : BoolProperty(name="Disable IK-restriction", default=False)
 
 	def execute(self, context):
 		for bone in context.selected_pose_bones:
@@ -38,6 +39,10 @@ class ConstraintIKToLimitRotation(bpy.types.Operator):
 					const.max_z = bone.ik_max_z
 					if (self.isLocal):
 						const.owner_space = "LOCAL"
+			if self.DisableSetting:
+				bone.use_ik_limit_x = False
+				bone.use_ik_limit_y = False
+				bone.use_ik_limit_z = False
 		return {'FINISHED'}
 
 ################

--- a/VIEW3D_MT_select_object.py
+++ b/VIEW3D_MT_select_object.py
@@ -40,7 +40,7 @@ class SelectBoundBoxSize(bpy.types.Operator):
 		return False
 
 	def execute(self, context):
-		context.scene.update()
+		#context.scene.update()
 		max_volume = -1
 		min_volume = 999999999999999
 		min_obj = None
@@ -167,7 +167,7 @@ class SelectGroupedModifiers(bpy.types.Operator):
 		active_type = context.active_object.type
 		for obj in context.selectable_objects:
 			if (GetModifiersString(obj) == active_modifiers and active_type == obj.type):
-				obj.select= True
+				obj.select_set(True)
 		return {'FINISHED'}
 
 class SelectGroupedSubsurfLevel(bpy.types.Operator):
@@ -193,7 +193,7 @@ class SelectGroupedSubsurfLevel(bpy.types.Operator):
 		active_type = context.active_object.type
 		for obj in context.selectable_objects:
 			if (GetSubsurfLevel(obj) == active_subsurf_level and active_type == obj.type):
-				obj.select= True
+				obj.select_set(True)
 		return {'FINISHED'}
 
 class SelectGroupedArmatureTarget(bpy.types.Operator):
@@ -225,7 +225,7 @@ class SelectGroupedArmatureTarget(bpy.types.Operator):
 		active_type = context.active_object.type
 		for obj in context.selectable_objects:
 			if (len(GetArmatureTarget(obj).intersection(active_armature_targets)) == len(active_armature_targets) and active_type == obj.type):
-				obj.select= True
+				obj.select_set(True)
 		return {'FINISHED'}
 
 class SelectGroupedSizeThan(bpy.types.Operator):
@@ -274,7 +274,7 @@ class SelectGroupedSizeThan(bpy.types.Operator):
 		if (not active_obj):
 			self.report(type={'ERROR'}, message="There is no active object")
 			return {'CANCELLED'}
-		context.scene.update()
+		#context.scene.update()
 		active_obj_size = GetSize(active_obj) * self.size_multi
 		for obj in context.selectable_objects:
 			if (self.select_type != 'ALL'):
@@ -400,13 +400,11 @@ class SelectGroupedEX(bpy.types.Menu):
 		column.operator("object.select_grouped", text="Parent").type = 'PARENT'
 		column.operator("object.select_grouped", text="Brother").type = 'SIBLINGS'
 		column.operator("object.select_grouped", text="Type").type = 'TYPE'
-		column.operator("object.select_grouped", text="Layer").type = 'LAYER'
-		column.operator("object.select_grouped", text="Group").type = 'GROUP'
+		column.operator("object.select_grouped", text="Collection").type = 'COLLECTION'
 		column.operator("object.select_grouped", text="Path").type = 'PASS'
-		column.operator("object.select_grouped", text="Color").type = 'COLOR'
-		column.operator("object.select_grouped", text="Property").type = 'PROPERTIES'
+		column.operator("object.select_grouped", text="Hook").type = 'HOOK'
 		column.operator("object.select_grouped", text="Keying Set").type = 'KEYINGSET'
-		column.operator("object.select_grouped", text="Lamp Type").type = 'LAMP_TYPE'
+		column.operator("object.select_grouped", text="Light Type").type = 'LIGHT_TYPE'
 		column.separator()
 		column.operator(SelectGroupedSizeThan.bl_idname, text="Bigger Than", icon='PLUGIN').mode = 'LARGER'
 		column.operator(SelectGroupedSizeThan.bl_idname, text="Smaller Than", icon='PLUGIN').mode = 'SMALLER'

--- a/VIEW3D_MT_select_pose.py
+++ b/VIEW3D_MT_select_pose.py
@@ -416,6 +416,7 @@ class SelectAxisOver(bpy.types.Operator):
 				bone.select = True
 			if (offset * direction <= tLoc * direction + threshold):
 				bone.select = True
+		bpy.ops.object.mode_set(mode=pre_mode)
 		return {'FINISHED'}
 
 ################################

--- a/VIEW3D_MT_uv_map.py
+++ b/VIEW3D_MT_uv_map.py
@@ -53,7 +53,6 @@ class CopyOtherUV(bpy.types.Operator):
 			if (me.vertices[me.loops[i].vertex_index].select):
 				active_uv.data[i].pin_uv = source_uv.data[i].pin_uv
 				active_uv.data[i].select = source_uv.data[i].select
-				active_uv.data[i].select_edge = source_uv.data[i].select_edge
 				active_uv.data[i].uv = source_uv.data[i].uv
 		bpy.ops.object.mode_set(mode=pre_mode)
 		return {'FINISHED'}

--- a/VIEW3D_MT_view.py
+++ b/VIEW3D_MT_view.py
@@ -22,13 +22,13 @@ class LocalViewEx(bpy.types.Operator):
 		pre_view_distance = context.region_data.view_distance
 		pre_view_location = context.region_data.view_location.copy()
 		pre_view_rotation = context.region_data.view_rotation.copy()
-		pre_cursor_location = context.space_data.cursor_location.copy()
+		pre_cursor_location = context.scene.cursor.location.copy()
 		bpy.ops.view3d.localview()
 		if (context.space_data.local_view):
 			self.report(type={'INFO'}, message="Local")
 		else:
 			self.report(type={'INFO'}, message="Global")
-		context.space_data.cursor_location = pre_cursor_location
+		context.scene.cursor.location = pre_cursor_location
 		context.region_data.view_distance = pre_view_distance
 		context.region_data.view_location = pre_view_location
 		context.region_data.view_rotation = pre_view_rotation
@@ -51,12 +51,12 @@ class TogglePanelsA(bpy.types.Operator):
 				uiW = region.width
 		if (1 < toolW or 1 < uiW):
 			if (1 < toolW):
-				bpy.ops.view3d.toolshelf()
+				context.space_data.show_region_toolbar = not context.space_data.show_region_toolbar
 			if (1 < uiW):
-				bpy.ops.view3d.properties()
+				context.space_data.show_region_ui = not context.space_data.show_region_ui
 		else:
-			bpy.ops.view3d.toolshelf()
-			bpy.ops.view3d.properties()
+			context.space_data.show_region_toolbar = not context.space_data.show_region_toolbar
+			context.space_data.show_region_ui = not context.space_data.show_region_ui
 		return {'FINISHED'}
 
 class TogglePanelsB(bpy.types.Operator):
@@ -74,12 +74,12 @@ class TogglePanelsB(bpy.types.Operator):
 			if (region.type == 'UI'):
 				uiW = region.width
 		if (toolW <= 1 and uiW <= 1):
-			bpy.ops.view3d.toolshelf()
+			context.space_data.show_region_toolbar = not context.space_data.show_region_toolbar
 		elif (toolW <= 1 and 1 < uiW):
-			bpy.ops.view3d.toolshelf()
+			context.space_data.show_region_toolbar = not context.space_data.show_region_toolbar
 		else:
-			bpy.ops.view3d.toolshelf()
-			bpy.ops.view3d.properties()
+			context.space_data.show_region_toolbar = not context.space_data.show_region_toolbar
+			context.space_data.show_region_ui = not context.space_data.show_region_ui
 		return {'FINISHED'}
 
 class TogglePanelsC(bpy.types.Operator):
@@ -97,27 +97,50 @@ class TogglePanelsC(bpy.types.Operator):
 			if (region.type == 'UI'):
 				uiW = region.width
 		if (toolW <= 1 and uiW <= 1):
-			bpy.ops.view3d.toolshelf()
+			context.space_data.show_region_toolbar = not context.space_data.show_region_toolbar
 		elif (1 < toolW and uiW <= 1):
-			bpy.ops.view3d.toolshelf()
-			bpy.ops.view3d.properties()
+			context.space_data.show_region_toolbar = not context.space_data.show_region_toolbar
+			context.space_data.show_region_ui = not context.space_data.show_region_ui
 		else:
-			bpy.ops.view3d.properties()
+			context.space_data.show_region_ui = not context.space_data.show_region_ui
 		return {'FINISHED'}
 
 class ToggleViewportShadeA(bpy.types.Operator):
 	bl_idname = "view3d.toggle_viewport_shade_a"
-	bl_label = "Shading Switch (Mode A)"
-	bl_description = "\"Wireframe\", \"solid\" => \"texture\" shading... We will switch"
-	bl_options = {'REGISTER'}
+	bl_label = "Shading Switch"
+	bl_description = "Wireframe => Solid => Material => Rendered (modifiable)"
+	bl_options = {'REGISTER', 'UNDO'}
+
+	items = [
+			("WIREFRAME", "Wireframe", "", 1),	("SOLID", "Solid", "", 2),
+			("MATERIAL", "Material", "", 3), ("RENDERED", "Rendered", "", 4)
+		]
+	FirstItem : EnumProperty(name="1st ", items=items)
+	SecondItem : EnumProperty(name="2nd ", items=[items[1],items[0],items[2],items[3]])
+	ThirdItem : EnumProperty(name="3rd ", items=[items[2],items[1],items[0],items[3]])
+	FourthItem : EnumProperty(name="4th ", items=[items[3],items[0],items[1],items[2]])
+	methods = [
+			("FOURLOOP", "1-2-3-4 loop", "", 1),
+			("THREELOOP", "1-2-3 loop", "", 2),
+			("TWOLOOP", "1-2 loop", "", 3),
+		]
+	loopMethod : EnumProperty(name="Loop Method", items=methods)
 
 	def execute(self, context):
-		if (context.space_data.viewport_shade == 'SOLID'):
-			context.space_data.viewport_shade = 'TEXTURED'
-		elif (context.space_data.viewport_shade == 'TEXTURED'):
-			context.space_data.viewport_shade = 'WIREFRAME'
+		if (context.space_data.shading.type == self.FirstItem):
+			context.space_data.shading.type = self.SecondItem
+		elif (context.space_data.shading.type == self.SecondItem):
+			if self.loopMethod == "TWOLOOP":
+				context.space_data.shading.type = self.FirstItem
+			else:
+				context.space_data.shading.type  = self.ThirdItem
+		elif (context.space_data.shading.type == self.ThirdItem):
+			if self.loopMethod == "FOURLOOP":
+				context.space_data.shading.type  = self.FourthItem
+			else:
+				context.space_data.shading.type  = self.FirstItem
 		else:
-			context.space_data.viewport_shade = 'SOLID'
+			context.space_data.shading.type = self.FirstItem
 		return {'FINISHED'}
 
 ################
@@ -139,13 +162,13 @@ class ViewNumpadPie(bpy.types.Menu): #
 	bl_description = "Is pie menu of preset views or (NUMPAD 1, 3, 7)"
 
 	def draw(self, context):
-		self.layout.menu_pie().operator("view3d.viewnumpad", text="Left", icon="TRIA_LEFT").type = "LEFT"
-		self.layout.menu_pie().operator("view3d.viewnumpad", text="Right", icon="TRIA_RIGHT").type = "RIGHT"
-		self.layout.menu_pie().operator("view3d.viewnumpad", text="Down", icon="TRIA_DOWN").type = "BOTTOM"
-		self.layout.menu_pie().operator("view3d.viewnumpad", text="Up", icon="TRIA_UP").type = "TOP"
-		self.layout.menu_pie().operator("view3d.viewnumpad", text="Back", icon="SHADING_BBOX").type = "BACK"
-		self.layout.menu_pie().operator("view3d.viewnumpad", text="Camera", icon="CAMERA_DATA").type = "CAMERA"
-		self.layout.menu_pie().operator("view3d.viewnumpad", text="Front", icon="SHADING_SOLID").type = "FRONT"
+		self.layout.menu_pie().operator("view3d.view_axis", text="Left", icon="TRIA_LEFT").type = "LEFT"
+		self.layout.menu_pie().operator("view3d.view_axis", text="Right", icon="TRIA_RIGHT").type = "RIGHT"
+		self.layout.menu_pie().operator("view3d.view_axis", text="Down", icon="TRIA_DOWN").type = "BOTTOM"
+		self.layout.menu_pie().operator("view3d.view_axis", text="Up", icon="TRIA_UP").type = "TOP"
+		self.layout.menu_pie().operator("view3d.view_axis", text="Back", icon="SHADING_BBOX").type = "BACK"
+		self.layout.menu_pie().operator("view3d.view_camera", text="Camera", icon="CAMERA_DATA")
+		self.layout.menu_pie().operator("view3d.view_axis", text="Front", icon="SHADING_SOLID").type = "FRONT"
 		self.layout.menu_pie().operator("view3d.view_persportho", text="Perspective/Orthographic", icon="BORDERMOVE")
 
 class ViewportShadePieOperator(bpy.types.Operator):
@@ -163,10 +186,8 @@ class ViewportShadePie(bpy.types.Menu): #
 	bl_description = "Is shading switch pie"
 
 	def draw(self, context):
-		self.layout.menu_pie().operator(SetViewportShade.bl_idname, text="Bounding Box", icon="SHADING_BBOX").mode = "BOUNDBOX"
-		self.layout.menu_pie().operator(SetViewportShade.bl_idname, text="Render", icon="SMOOTH").mode = "RENDERED"
+		self.layout.menu_pie().operator(SetViewportShade.bl_idname, text="Render", icon="SHADING_TEXTURE").mode = "RENDERED"
 		self.layout.menu_pie().operator(SetViewportShade.bl_idname, text="Solid", icon="SHADING_SOLID").mode = "SOLID"
-		self.layout.menu_pie().operator(SetViewportShade.bl_idname, text="Texture", icon="SHADING_TEXTURE").mode = "TEXTURED"
 		self.layout.menu_pie().operator(SetViewportShade.bl_idname, text="Wire Frame", icon="SHADING_WIRE").mode = "WIREFRAME"
 		self.layout.menu_pie().operator(SetViewportShade.bl_idname, text="Material", icon="MATERIAL").mode = "MATERIAL"
 class SetViewportShade(bpy.types.Operator): #
@@ -178,7 +199,7 @@ class SetViewportShade(bpy.types.Operator): #
 	mode : StringProperty(name="Shading", default="SOLID")
 
 	def execute(self, context):
-		context.space_data.viewport_shade = self.mode
+		context.space_data.shading.type = self.mode
 		return {'FINISHED'}
 
 class LayerPieOperator(bpy.types.Operator):
@@ -195,130 +216,108 @@ class LayerPie(bpy.types.Menu):
 	bl_label = "Layer Pie Menu"
 	bl_description = "Is pie menu toggle layer visibility"
 
+	def flatten(self, layer_collection, parent_name=""):
+		flat = []
+		for coll in layer_collection.children:
+			if len(coll.children) > 0:
+				flat.append((coll, f"{parent_name},{layer_collection.name}"))
+				flat += self.flatten(coll, f"{parent_name},{layer_collection.name}")
+			else:
+				flat.append((coll, f"{parent_name},{layer_collection.name}"))
+		return flat
+
 	def draw(self, context):
 		box = self.layout.box()
 		column = box.column()
 		row = column.row()
-		row.label(text="Select layer switch (shift + add choice + CTRL semi-selection + ALT half-clear)", icon='PLUGIN')
+		row.label(text="Toggle collection show/hide (shift: Wireframe, ctrl:Hide others)", icon='PLUGIN')
 		row = column.row()
-		operator = row.operator(LayerPieRun.bl_idname, text="01", icon=self.GetIcon(0))
-		operator.nr = 1
-		operator = row.operator(LayerPieRun.bl_idname, text="02", icon=self.GetIcon(1))
-		operator.nr = 2
-		operator = row.operator(LayerPieRun.bl_idname, text="03", icon=self.GetIcon(2))
-		operator.nr = 3
-		operator = row.operator(LayerPieRun.bl_idname, text="04", icon=self.GetIcon(3))
-		operator.nr = 4
-		operator = row.operator(LayerPieRun.bl_idname, text="05", icon=self.GetIcon(4))
-		operator.nr = 5
-		row.separator()
-		operator = row.operator(LayerPieRun.bl_idname, text="06", icon=self.GetIcon(5))
-		operator.nr = 6
-		operator = row.operator(LayerPieRun.bl_idname, text="07", icon=self.GetIcon(6))
-		operator.nr = 7
-		operator = row.operator(LayerPieRun.bl_idname, text="08", icon=self.GetIcon(7))
-		operator.nr = 8
-		operator = row.operator(LayerPieRun.bl_idname, text="09", icon=self.GetIcon(8))
-		operator.nr = 9
-		operator = row.operator(LayerPieRun.bl_idname, text="10", icon=self.GetIcon(9))
-		operator.nr = 10
-		row = column.row()
-		operator = row.operator(LayerPieRun.bl_idname, text="11", icon=self.GetIcon(10))
-		operator.nr = 11
-		operator = row.operator(LayerPieRun.bl_idname, text="12", icon=self.GetIcon(11))
-		operator.nr = 12
-		operator = row.operator(LayerPieRun.bl_idname, text="13", icon=self.GetIcon(12))
-		operator.nr = 13
-		operator = row.operator(LayerPieRun.bl_idname, text="14", icon=self.GetIcon(13))
-		operator.nr = 14
-		operator = row.operator(LayerPieRun.bl_idname, text="15", icon=self.GetIcon(14))
-		operator.nr = 15
-		row.separator()
-		operator = row.operator(LayerPieRun.bl_idname, text="16", icon=self.GetIcon(15))
-		operator.nr = 16
-		operator = row.operator(LayerPieRun.bl_idname, text="17", icon=self.GetIcon(16))
-		operator.nr = 17
-		operator = row.operator(LayerPieRun.bl_idname, text="18", icon=self.GetIcon(17))
-		operator.nr = 18
-		operator = row.operator(LayerPieRun.bl_idname, text="19", icon=self.GetIcon(18))
-		operator.nr = 19
-		operator = row.operator(LayerPieRun.bl_idname, text="20", icon=self.GetIcon(19))
-		operator.nr = 20
-	def GetIcon(self, layer):
-		isIn = False
-		isHalf = False
-		objs = []
-		for obj in bpy.data.objects:
-			if (obj.layers[layer]):
-				isIn = True
-				objs.append(obj)
-		if (objs):
-			for obj in objs:
-				if (obj.display_type != 'WIRE'):
-					break
-			else:
-				isHalf = True
-		if (bpy.context.scene.layers[layer]):
-			if (isHalf):
-				return 'WIRE'
-			if (isIn):
-				return 'RADIOBUT_ON'
-			return 'RADIOBUT_OFF'
+		for col in context.view_layer.layer_collection.children:
+			column = row.column()
+			operator = column.operator(LayerPieRun.bl_idname, text=f"{col.name}", icon=self.GetIcon(col))
+			operator.name = col.name
+			operator.parent_names = ""
+			flatten_nest = self.flatten(col)
+			for coll in flatten_nest:
+				operator = column.operator(LayerPieRun.bl_idname, text=f"{coll[0].name}", icon=self.GetIcon(coll[0]))
+				operator.name = coll[0].name
+				operator.parent_names = coll[1]
+	def GetIcon(self, layer_collection):
+		if layer_collection.hide_viewport:
+			return "HIDE_ON"
+		for obj in layer_collection.collection.objects[:5]:
+			if (obj.display_type != 'WIRE'):
+				return "HIDE_OFF"
 		else:
-			if (isHalf):
-				return 'SOLID'
-			if (isIn):
-				return 'DOT'
-			return 'BLANK1'
+			return 'SHADING_WIRE'
 class LayerPieRun(bpy.types.Operator): #
 	bl_idname = "view3d.layer_pie_run"
 	bl_label = "Layer Pie Menu"
-	bl_description = "Shows or hides layer (shift + add choice + CTRL semi-selection + ALT half-clear)"
+	bl_description = "Shows or hides collection"
 	bl_options = {'REGISTER', 'UNDO'}
 
-	nr : IntProperty(name="Layer Number")
-	extend : BoolProperty(name="Select Extension", default=False)
-	half : BoolProperty(name="Half Select", default=False)
-	unhalf : BoolProperty(name="Half-Unselect", default=False)
+	name : StringProperty(name="Collection Name")
+	parent_names : StringProperty(name="Parent-Collections\' Names")
+	exclusive : BoolProperty(name="Hide Others", default=False)
+	wire : BoolProperty(name="Wireframe", default=False)
+	#unhalf : BoolProperty(name="Half-Unselect", default=False)
 
 	def execute(self, context):
-		nr = self.nr - 1
-		if (self.half):
-			context.scene.layers[nr] = True
-			for obj in context.blend_data.objects:
-				if (obj.layers[nr]):
-					obj.show_all_edges = True
-					obj.display_type = 'WIRE'
-		elif (self.unhalf):
-			context.scene.layers[nr] = True
-			for obj in context.blend_data.objects:
-				if (obj.layers[nr]):
-					obj.display_type = 'TEXTURED'
-		elif (self.extend):
-			context.scene.layers[nr] = not context.scene.layers[nr]
+		par_names = [x for x in self.parent_names.split(",") if not len(x) == 0]
+		if not par_names:
+			coll = context.view_layer.layer_collection.children[self.name]
+			if (self.exclusive):
+				for col in context.view_layer.layer_collection.children:
+					if col.name != self.name: col.hide_viewport = True
 		else:
-			context.scene.layers[nr] = not context.scene.layers[nr]
-			for i in range(len(context.scene.layers)):
-				if (nr != i):
-					context.scene.layers[i] = False
+			par = context.view_layer.layer_collection.children[par_names[0]]
+			if (self.exclusive):
+				for col in context.view_layer.layer_collection.children:
+					if col.name != par_names[0]: col.hide_viewport = True
+			try:
+				for name in par_names[1:]:
+					if (self.exclusive):
+						for col in par.children:
+							if col.name != name: col.hide_viewport = True
+					par = par.children[name]
+			except IndexError:
+				pass		
+			coll = par.children[self.name]
+		if (self.exclusive):
+			coll.hide_viewport = False
+			return {'FINISHED'}
+		if (self.wire):
+			for obj in coll.collection.objects:
+				obj.show_all_edges = True
+				if obj.display_type != 'WIRE':
+					obj.display_type = 'WIRE'
+				else:
+					obj.display_type = 'TEXTURED'
+		#elif (not self.unhalf):
+		#	context.scene.layers[nr] = True
+		#	for obj in context.blend_data.objects:
+		#		if (obj.layers[nr]):
+		#			obj.display_type = 'TEXTURED'
+		else:
+			coll.hide_viewport = not coll.hide_viewport
 		return {'FINISHED'}
 	def invoke(self, context, event):
 		if (event.ctrl):
-			self.extend = False
-			self.half = True
-			self.unhalf = False
+			self.exclusive = True
+			self.wire = False
+			#self.unhalf = False
 		elif (event.shift):
-			self.extend = True
-			self.half = False
-			self.unhalf = False
+			self.exclusive = False
+			self.wire = True
+			#self.unhalf = False
 		elif (event.alt):
-			self.extend = False
-			self.half = False
-			self.unhalf = True
+			self.exclusive = False
+			self.wire = False
+			#self.unhalf = True
 		else:
-			self.extend = False
-			self.half = False
-			self.unhalf = False
+			self.exclusive = False
+			self.wire = False
+			#self.unhalf = False
 		return self.execute(context)
 
 class PanelPieOperator(bpy.types.Operator):
@@ -366,9 +365,11 @@ class RunPanelPie(bpy.types.Operator): #
 				if (1 < region.width):
 					toolshelf = True
 		if (properties != self.properties):
-			bpy.ops.view3d.properties()
+			context.space_data.show_region_ui = not context.space_data.show_region_ui
+			#bpy.ops.view3d.properties()
 		if (toolshelf != self.toolshelf):
-			bpy.ops.view3d.toolshelf()
+			context.space_data.show_region_toolbar = not context.space_data.show_region_toolbar
+			#bpy.ops.view3d.toolshelf()
 		return {'FINISHED'}
 
 ################
@@ -397,7 +398,7 @@ class PieMenu(bpy.types.Menu):
 	def draw(self, context):
 		self.layout.operator(ViewNumpadPieOperator.bl_idname, icon='PLUGIN')
 		self.layout.operator(ViewportShadePieOperator.bl_idname, icon='PLUGIN')
-		self.layout.operator(LayerPieOperator.bl_idname, text="Layer", icon='PLUGIN')
+		self.layout.operator(LayerPieOperator.bl_idname, text="Collection", icon='PLUGIN')
 		self.layout.operator(PanelPieOperator.bl_idname, text="Panel Switch", icon='PLUGIN')
 
 ################

--- a/VIEW3D_MT_view_align.py
+++ b/VIEW3D_MT_view_align.py
@@ -38,10 +38,10 @@ class ResetView(bpy.types.Operator):
 	bl_options = {'REGISTER', 'UNDO'}
 
 	def execute(self, context):
-		pre_cursor_location = context.space_data.cursor_location[:]
-		context.space_data.cursor_location = (0.0, 0.0, 0.0)
+		pre_cursor_location = context.scene.cursor.location[:]
+		context.scene.cursor.location = (0.0, 0.0, 0.0)
 		bpy.ops.view3d.view_center_cursor()
-		context.space_data.cursor_location = pre_cursor_location[:]
+		context.scene.cursor.location = pre_cursor_location[:]
 		return {'FINISHED'}
 
 class SelectAndView(bpy.types.Operator):
@@ -80,30 +80,24 @@ class SnapMeshView(bpy.types.Operator):
 	mouse_co : IntVectorProperty(name="Mouse Position", size=2)
 
 	def execute(self, context):
-		preGp = context.scene.grease_pencil
-		preGpSource = context.scene.tool_settings.grease_pencil_source
+		preAnno = context.scene.grease_pencil
 		preCursorCo = bpy.context.scene.cursor.location[:]
-		context.space_data.cursor_location = context.region_data.view_location[:]
-		context.scene.tool_settings.grease_pencil_source = 'SCENE'
-		if (preGp):
-			tempGp = preGp
-		else:
-			try:
-				tempGp = bpy.data.grease_pencil["temp"]
-			except KeyError:
-				tempGp = bpy.data.grease_pencil.new("temp")
-		context.scene.grease_pencil = tempGp
-		tempLayer = tempGp.layers.new("temp", set_active=True)
-		tempGp.draw_mode = 'SURFACE'
-		bpy.ops.gpencil.draw(mode='DRAW_POLY', stroke=[{"name":"", "pen_flip":False, "is_start":True, "location":(0, 0, 0),"mouse":self.mouse_co, "pressure":1, "time":0, "size":0}, {"name":"", "pen_flip":False, "is_start":True, "location":(0, 0, 0),"mouse":(0, 0), "pressure":1, "time":0, "size":0}])
+		context.scene.cursor.location = context.region_data.view_location[:]
+		try:
+			tempAnno = bpy.data.grease_pencils["temp"]
+		except KeyError:
+			tempAnno = bpy.data.grease_pencils.new("temp")
+		context.scene.grease_pencil = tempAnno
+		tempLayer = tempAnno.layers.new("temp", set_active=True)
+		context.scene.tool_settings.annotation_stroke_placement_view3d = 'SURFACE'
+		bpy.ops.gpencil.annotate(mode='DRAW_POLY', stroke=[{"name":"", "pen_flip":False, "is_start":True, "location":(0, 0, 0),"mouse":self.mouse_co, "pressure":1, "time":0, "size":0}, {"name":"", "pen_flip":False, "is_start":True, "location":(0, 0, 0),"mouse":(0, 0), "pressure":1, "time":0, "size":0}])
 		bpy.context.scene.cursor.location = tempLayer.frames[-1].strokes[-1].points[0].co
 		bpy.ops.view3d.view_center_cursor()
 		bpy.context.scene.cursor.location = preCursorCo
-		tempGp.layers.remove(tempLayer)
-		tempGp.user_clear()
-		bpy.data.grease_pencil.remove(tempGp)
-		context.scene.grease_pencil = preGp
-		context.scene.tool_settings.grease_pencil_source = preGpSource
+		tempAnno.layers.remove(tempLayer)
+		tempAnno.user_clear()
+		bpy.data.grease_pencils.remove(tempAnno)
+		context.scene.grease_pencil = preAnno
 		return {'FINISHED'}
 	def invoke(self, context, event):
 		self.mouse_co[0] = event.mouse_region_x
@@ -142,25 +136,19 @@ class SnapMeshViewAndCursor(bpy.types.Operator):
 	mouse_co : IntVectorProperty(name="Mouse Position", size=2)
 
 	def execute(self, context):
-		preGp = context.scene.grease_pencil
-		preGpSource = context.scene.tool_settings.grease_pencil_source
-		context.scene.tool_settings.grease_pencil_source = 'SCENE'
-		if (preGp):
-			tempGp = preGp
-		else:
-			try:
-				tempGp = bpy.data.grease_pencil["temp"]
-			except KeyError:
-				tempGp = bpy.data.grease_pencil.new("temp")
-		context.scene.grease_pencil = tempGp
-		tempLayer = tempGp.layers.new("temp", set_active=True)
-		tempGp.draw_mode = 'SURFACE'
-		bpy.ops.gpencil.draw(mode='DRAW_POLY', stroke=[{"name":"", "pen_flip":False, "is_start":True, "location":(0, 0, 0),"mouse":self.mouse_co, "pressure":1, "time":0, "size":0}, {"name":"", "pen_flip":False, "is_start":True, "location":(0, 0, 0),"mouse":(0, 0), "pressure":1, "time":0, "size":0}])
+		preAnno = context.scene.grease_pencil
+		try:
+			tempAnno = bpy.data.grease_pencils["temp"]
+		except KeyError:
+			tempAnno = bpy.data.grease_pencils.new("temp")
+		context.scene.grease_pencil = tempAnno
+		tempLayer = tempAnno.layers.new("temp", set_active=True)
+		context.scene.tool_settings.annotation_stroke_placement_view3d = 'SURFACE'
+		bpy.ops.gpencil.annotate(mode='DRAW_POLY', stroke=[{"name":"", "pen_flip":False, "is_start":True, "location":(0, 0, 0),"mouse":self.mouse_co, "pressure":1, "time":0, "size":0}, {"name":"", "pen_flip":False, "is_start":True, "location":(0, 0, 0),"mouse":(0, 0), "pressure":1, "time":0, "size":0}])
 		bpy.context.scene.cursor.location = tempLayer.frames[-1].strokes[-1].points[0].co
 		bpy.ops.view3d.view_center_cursor()
-		tempGp.layers.remove(tempLayer)
-		context.scene.grease_pencil = preGp
-		context.scene.tool_settings.grease_pencil_source = preGpSource
+		tempAnno.layers.remove(tempLayer)
+		context.scene.grease_pencil = preAnno
 		return {'FINISHED'}
 	def invoke(self, context, event):
 		self.mouse_co[0] = event.mouse_region_x

--- a/VIEW3D_MT_view_align_selected.py
+++ b/VIEW3D_MT_view_align_selected.py
@@ -2,6 +2,7 @@
 # "3D View" Area > "View" Menu > "Align View" Menu > "Align View to Active" Menu
 
 import bpy
+from bpy.props import *
 
 ################
 # オペレーター #
@@ -12,21 +13,31 @@ class Viewnumpad7AlignEX(bpy.types.Operator):
 	bl_label = "View Front"
 	bl_description = "watch face from selected surface normal direction"
 	bl_options = {'REGISTER', 'UNDO'}
+	items = [
+		("FRONT", "Front", "", 1),
+		("BACK", "Back", "", 2),
+		("LEFT", "Left", "", 3),
+		("RIGHT", "Right", "", 4),
+		("TOP", "Top", "", 5),
+		("BOTTOM", "Bottom", "", 6),
+	]
+
+	method : EnumProperty(name="View Method", items=items)
 	
 	def execute(self, context):
 		pre_smooth_view = context.preferences.view.smooth_view
 		context.preferences.view.smooth_view = 0
-		bpy.ops.view3d.viewnumpad(type='TOP', align_active=True)
+		bpy.ops.view3d.view_axis(type=self.method, align_active=True)
 		bpy.ops.view3d.view_selected_ex()
 		threshold = 0.01
 		angle = 0.001
 		while True:
-			bpy.ops.view3d.view_roll(angle=angle, type='ROLLANGLE')
+			bpy.ops.view3d.view_roll(angle=angle, type='ANGLE')
 			view_rotation = context.region_data.view_rotation.copy().to_euler()
 			if (-threshold <= view_rotation.y <= threshold):
 					break
 		if (view_rotation.x < 0):
-			bpy.ops.view3d.view_roll(angle=3.14159, type='ROLLANGLE')
+			bpy.ops.view3d.view_roll(angle=3.14159, type='ANGLE')
 		context.preferences.view.smooth_view = pre_smooth_view
 		return {'FINISHED'}
 

--- a/VIEW3D_PT_addon_sidebar.py
+++ b/VIEW3D_PT_addon_sidebar.py
@@ -1,0 +1,100 @@
+# 「3Dビュー」エリア > サイドバー > 「Scramble」パネル
+# "3D View" Area > Side bar> "Scramble" Panel
+
+import bpy
+from . import VIEW3D_PT_layers, VIEW3D_PT_transform_orientations, VIEW3D_PT_view3d_cursor, VIEW3D_PT_view3d_name, VIEW3D_PT_view3d_properties
+
+if 'bpy' in locals():
+	import importlib
+	importlib.reload(VIEW3D_PT_layers)
+	importlib.reload(VIEW3D_PT_transform_orientations)
+	importlib.reload(VIEW3D_PT_view3d_cursor)
+	importlib.reload(VIEW3D_PT_view3d_name)
+	importlib.reload(VIEW3D_PT_view3d_properties)
+
+################
+# オペレーター #
+################
+
+##########
+# パネル #
+##########
+
+class VIEW3D_PT_scramble_view3d_properties(bpy.types.Panel):
+	bl_space_type = "VIEW_3D"
+	bl_region_type = "UI"
+	bl_category = "Scramble"
+	bl_label = "Properties"
+	bl_options = {'DEFAULT_CLOSED'}
+	def draw(self, context):
+		VIEW3D_PT_view3d_properties.menu(self, context)
+
+
+class VIEW3D_PT_scramble_view3d_name(bpy.types.Panel):
+	bl_space_type = "VIEW_3D"
+	bl_region_type = "UI"
+	bl_category = "Scramble"
+	bl_label = "Item name"
+	bl_options = {'DEFAULT_CLOSED'}
+	def draw(self, context):
+		VIEW3D_PT_view3d_name.menu(self, context)
+
+
+class VIEW3D_PT_scramble_view3d_cursor(bpy.types.Panel):
+	bl_space_type = "VIEW_3D"
+	bl_region_type = "UI"
+	bl_category = "Scramble"
+	bl_label = "Cursor"
+	bl_options = {'DEFAULT_CLOSED'}
+	def draw(self, context):
+		VIEW3D_PT_view3d_cursor.menu(self, context)
+
+
+class VIEW3D_PT_scramble_view3d_orientation(bpy.types.Panel):
+	bl_space_type = "VIEW_3D"
+	bl_region_type = "UI"
+	bl_category = "Scramble"
+	bl_label = "Transform Orientation"
+	bl_options = {'DEFAULT_CLOSED'}
+	def draw(self, context):
+		VIEW3D_PT_transform_orientations.menu(self, context)
+
+
+class VIEW3D_PT_scramble_view3d_collrections(bpy.types.Panel):
+	bl_space_type = 'VIEW_3D'
+	bl_region_type = 'UI'
+	bl_category = "Scramble"
+	bl_label = "Collection Display Panel"
+	bl_options = {'DEFAULT_CLOSED'}
+	def draw(self, context):
+		VIEW3D_PT_layers.menu(self, context)
+
+
+################
+# クラスの登録 #
+################
+
+classes = [
+	VIEW3D_PT_scramble_view3d_properties,
+	VIEW3D_PT_scramble_view3d_name,
+	VIEW3D_PT_scramble_view3d_cursor,
+	VIEW3D_PT_scramble_view3d_orientation,
+	VIEW3D_PT_scramble_view3d_collrections
+]
+
+def register():
+	for cls in classes:
+		bpy.utils.register_class(cls)
+
+def unregister():
+	for cls in classes:
+		bpy.utils.unregister_class(cls)
+
+
+################
+# メニュー追加 #
+################
+
+# メニューを登録する関数
+def menu(self, context):
+	pass

--- a/VIEW3D_PT_layers.py
+++ b/VIEW3D_PT_layers.py
@@ -8,86 +8,84 @@ from bpy.props import *
 # オペレーター #
 ################
 
-class GroupLayers(bpy.types.Operator):
-	bl_idname = "object.group_layers"
-	bl_label = "Toggle Show/Hide Groups"
-	bl_description = "Switch Show / Hide group has"
-	bl_options = {'REGISTER', 'UNDO'}
+class CollectionShowHide(bpy.types.Operator): #
+	bl_idname = "view3d.collection_show_hide"
+	bl_label = "Toggle Show/Hide Collections"
+	bl_description = "Shows or hides collection"
+	bl_options = {'REGISTER'}
 
-	group : StringProperty(name="Group Name")
+	name : StringProperty(name="Collection Name")
+	parent_names : StringProperty(name="Parent-Collections\' Names")
+	exclusive : BoolProperty(name="Hide Others", default=False)
+	wire : BoolProperty(name="Wireframe", default=False)
 
 	def execute(self, context):
-		for obj in bpy.data.objects:
-			for l1 in obj.layers:
-				for l2 in context.scene.layers:
-					if (l1 and l2):
-						if (self.group != ""):
-							for group in obj.users_group:
-								if (group.name == self.group):
-									obj.hide = False
-									break
-							else:
-								obj.hide = True
-						else:
-							if (len(obj.users_group) == 0):
-								obj.hide = False
-							else:
-								obj.hide = True
+		par_names = [x for x in self.parent_names.split(",") if not len(x) == 0]
+		if not par_names:
+			coll = context.view_layer.layer_collection.children[self.name]
+			if (self.exclusive):
+				for col in context.view_layer.layer_collection.children:
+					if col.name != self.name: col.hide_viewport = True
+		else:
+			par = context.view_layer.layer_collection.children[par_names[0]]
+			if (self.exclusive):
+				for col in context.view_layer.layer_collection.children:
+					if col.name != par_names[0]: col.hide_viewport = True
+			try:
+				for name in par_names[1:]:
+					if (self.exclusive):
+						for col in par.children:
+							if col.name != name: col.hide_viewport = True
+					par = par.children[name]
+			except IndexError:
+				pass		
+			coll = par.children[self.name]
+		if (self.exclusive):
+			coll.hide_viewport = False
+			return {'FINISHED'}
+		if (self.wire):
+			for obj in coll.collection.objects:
+				obj.show_all_edges = True
+				if obj.display_type != 'WIRE':
+					obj.display_type = 'WIRE'
+				else:
+					obj.display_type = 'TEXTURED'
+		else:
+			coll.hide_viewport = not coll.hide_viewport
 		return {'FINISHED'}
+	def invoke(self, context, event):
+		if (event.shift):
+			self.exclusive = False
+			self.wire = True
+		return self.execute(context)
 
-##########
-# パネル #
-##########
+def flatten(layer_collection, parent_name=""):
+	flat = []
+	for coll in layer_collection.children:
+		if len(coll.children) > 0:
+			flat.append((coll, f"{parent_name},{layer_collection.name}"))
+			flat += flatten(coll, f"{parent_name},{layer_collection.name}")
+		else:
+			flat.append((coll, f"{parent_name},{layer_collection.name}"))
+			flat.append((None, None))
+	return flat
 
-class ObjectSelectPanel(bpy.types.Panel):
-	bl_idname = "VIEW3D_PT_layers"
-	bl_label = "ObjectSelectPanel"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'UI'
-	bl_options = {'DEFAULT_CLOSED'}
+def GetIcon(layer_collection):
+	if layer_collection.hide_viewport:
+		return "HIDE_ON"
+	for obj in layer_collection.collection.objects[:5]:
+		if (obj.display_type != 'WIRE'):
+			return "HIDE_OFF"
+	else:
+		return 'SHADING_WIRE'
 
-	@classmethod
-	def poll(cls, context):
-		return (context.object is not None)
-#
-#	def draw_header(self, context):
-#		row = self.layout.row()
-#		row.scale_x = 0.7
-#		row.scale_y = 0.7
-#		row.prop(context.scene, 'layers', text="")
-#
-	def draw(self, context):
-		if (context.object):
-			if (context.object.type == 'ARMATURE'):
-				self.layout.label(text="Bone Layer")
-				col = self.layout.column()
-				col.scale_y = 0.7
-				col.prop(context.object.data, 'layers', text="")
-		self.layout.label(text="Layers by Groups")
-		objs = []
-		for obj in bpy.data.objects:
-			for i in range(len(obj.layers)):
-				if (obj.layers[i] and context.scene.layers[i]):
-					objs.append(obj)
-		groups = []
-		for obj in objs:
-			for group in obj.users_group:
-				if (not group in groups):
-					groups.append(group)
-		row = self.layout.row(align=True)
-		row.operator('object.hide_view_clear', text="Show All", icon='RESTRICT_VIEW_OFF')
-		row.operator(GroupLayers.bl_idname, text="Non-Group", icon='FILE').group = ''
-		col = self.layout.column(align=True)
-		for group in groups:
-			col.operator(GroupLayers.bl_idname, text=group.name, icon='PLUGIN').group = group.name
 
 ################
 # クラスの登録 #
 ################
 
 classes = [
-	GroupLayers,
-	ObjectSelectPanel
+	CollectionShowHide
 ]
 
 def register():
@@ -103,6 +101,59 @@ def unregister():
 # メニュー追加 #
 ################
 
+# メニューのオン/オフの判定
+def IsMenuEnable(self_id):
+	for id in bpy.context.preferences.addons[__name__.partition('.')[0]].preferences.disabled_menu.split(','):
+		if (id == self_id):
+			return False
+	else:
+		return True
+
 # メニューを登録する関数
 def menu(self, context):
-	pass
+	if (IsMenuEnable(__name__.split('.')[-1])):
+		#coll_dic = {c.name:  for }
+		if (context.object):
+			if (context.object.type == 'ARMATURE'):
+				self.layout.label(text="Bone Layer")
+				col = self.layout.column()
+				col.scale_y = 0.7
+				col.prop(context.object.data, 'layers', text="")
+		self.layout.separator(factor=1.0)
+		if context.active_object:
+			obj_par_collection = context.active_object.users_collection[0].name
+		else:
+			obj_par_collection = ""
+		for col in context.view_layer.layer_collection.children:
+			row = self.layout.row()
+			if col.name == obj_par_collection:
+				row.label(icon='KEYTYPE_KEYFRAME_VEC')
+			else:
+				row.label(icon='HANDLETYPE_AUTO_VEC')
+			op1 = row.operator(CollectionShowHide.bl_idname, text=f"{col.name}", icon='NONE', emboss=False)
+			op1.name, op1.parent_names = [col.name, ""]
+			op1.exclusive, op1.wire = [True, False]
+			op2 = row.operator(CollectionShowHide.bl_idname, text="", icon=GetIcon(col), emboss=False)
+			op2.name, op2.parent_names = [col.name, ""]
+			op2.exclusive, op2.wire = [False, False]
+			flatten_nest = flatten(col)[:-1]
+			for coll in flatten_nest:
+				if coll[0] == None:
+					self.layout.separator(factor=0.3)
+				else:
+					row = self.layout.row()
+					if coll[0].name == obj_par_collection:
+						row.label(icon='KEYTYPE_KEYFRAME_VEC')
+					else:
+						row.label(icon='HANDLETYPE_AUTO_VEC')				
+					op1 = row.operator(CollectionShowHide.bl_idname, text=f"{coll[0].name}", icon='NONE', emboss=False)
+					op1.name, op1.parent_names = [coll[0].name, coll[1]]
+					op1.exclusive, op1.wire = [True, False]
+					op2 = row.operator(CollectionShowHide.bl_idname, text="", icon=GetIcon(coll[0]), emboss=False)
+					op2.name, op2.parent_names = [coll[0].name, coll[1]]
+					op2.exclusive, op2.wire = [False, False]
+			self.layout.separator(factor=1.0)
+		self.layout.label(text="(shift: Toggle Wireframe)")
+
+	if (context.preferences.addons[__name__.partition('.')[0]].preferences.use_disabled_menu):
+		self.layout.operator('wm.toggle_menu_enable', icon='CANCEL').id = __name__.split('.')[-1]

--- a/VIEW3D_PT_tools_imagepaint_external.py
+++ b/VIEW3D_PT_tools_imagepaint_external.py
@@ -62,7 +62,7 @@ def IsMenuEnable(self_id):
 def menu(self, context):
 	if (IsMenuEnable(__name__.split('.')[-1])):
 		col = self.layout.column(align=True)
-		col.label(text="Add Quick Edit", icon='PLUGIN')
+		col.label(text="=== Quick Menu for Editor ===", icon='NONE')
 		if (context.preferences.addons[__name__.partition('.')[0]].preferences.image_editor_path_1):
 			path = os.path.basename(context.preferences.addons[__name__.partition('.')[0]].preferences.image_editor_path_1)
 			name, ext = os.path.splitext(path)

--- a/VIEW3D_PT_transform_orientations.py
+++ b/VIEW3D_PT_transform_orientations.py
@@ -2,6 +2,7 @@
 # "3D View" Area > Propaties > "Transform Orientations" Panel
 
 import bpy
+from bpy.ops import *
 
 ################
 # オペレーター #
@@ -23,6 +24,13 @@ def IsMenuEnable(self_id):
 def menu(self, context):
 	if (IsMenuEnable(__name__.split('.')[-1])):
 		box = self.layout.box()
-		box.props_enum(context.space_data, 'transform_orientation')
+		box.props_enum(context.scene.transform_orientation_slots[0], "type")
+		row = self.layout.row()
+		operator = row.operator("transform.create_orientation", text="", icon='ADD')
+		operator.use = True
+		operator.overwrite = True
+		if context.scene.transform_orientation_slots[0].custom_orientation != None:
+			row.prop(context.scene.transform_orientation_slots[0].custom_orientation, "name", text="")
+			row.operator("transform.delete_orientation", text="", icon='PANEL_CLOSE')
 	if (context.preferences.addons[__name__.partition('.')[0]].preferences.use_disabled_menu):
 		self.layout.operator('wm.toggle_menu_enable', icon='CANCEL').id = __name__.split('.')[-1]

--- a/VIEW3D_PT_view3d_name.py
+++ b/VIEW3D_PT_view3d_name.py
@@ -24,16 +24,17 @@ def menu(self, context):
 	if (IsMenuEnable(__name__.split('.')[-1])):
 		row = self.layout.row(align=True)
 		row.alignment = 'RIGHT'
-		row.label("To Clipboard", icon='COPYDOWN')
+		row.label(text="To Clipboard", icon='COPYDOWN')
 		row.operator('object.copy_object_name', icon='OBJECT_DATAMODE', text="")
 		if (context.active_bone or context.active_pose_bone):
 			row.operator('object.copy_bone_name', icon='BONE_DATA', text="")
 		row.operator('object.copy_data_name', icon='EDITMODE_HLT', text="")
 		row = self.layout.row(align=True)
 		row.alignment = 'RIGHT'
-		row.label("Name Sync", icon='LINKED')
+		row.label(text="Name Sync", icon='LINKED')
 		row.operator('object.object_name_to_data_name', icon='TRIA_DOWN_BAR', text="")
 		row.operator('object.data_name_to_object_name', icon='TRIA_UP_BAR', text="")
-		self.layout.template_ID(context.object, 'data')
+		if context.object:
+			self.layout.template_ID(context.object, 'data')
 	if (context.preferences.addons[__name__.partition('.')[0]].preferences.use_disabled_menu):
 		self.layout.operator('wm.toggle_menu_enable', icon='CANCEL').id = __name__.split('.')[-1]

--- a/VIEW3D_PT_view3d_properties.py
+++ b/VIEW3D_PT_view3d_properties.py
@@ -124,8 +124,8 @@ def IsMenuEnable(self_id):
 # メニューを登録する関数
 def menu(self, context):
 	if (IsMenuEnable(__name__.split('.')[-1])):
-		self.layout.prop(context.preferences.view, 'use_zoom_to_mouse')
-		self.layout.prop(context.preferences.view, 'use_rotate_around_active')
+		self.layout.prop(context.preferences.inputs, 'use_zoom_to_mouse')
+		self.layout.prop(context.preferences.inputs, 'use_rotate_around_active')
 		self.layout.prop(context.scene, 'sync_mode')
 		box = self.layout.box()
 		col = box.column(align=True)

--- a/__init__.py
+++ b/__init__.py
@@ -97,6 +97,7 @@ if "bpy" in locals():
 	"VIEW3D_MT_view",
 	"VIEW3D_MT_view_align",
 	"VIEW3D_MT_view_align_selected",
+	"VIEW3D_PT_addon_sidebar",
 	"VIEW3D_PT_imapaint_tools_missing",
 	"VIEW3D_PT_layers",
 	"VIEW3D_PT_slots_projectpaint",
@@ -192,6 +193,7 @@ else:
 	VIEW3D_MT_view,
 	VIEW3D_MT_view_align,
 	VIEW3D_MT_view_align_selected,
+	VIEW3D_PT_addon_sidebar,
 	VIEW3D_PT_imapaint_tools_missing,
 	VIEW3D_PT_layers,
 	VIEW3D_PT_slots_projectpaint,
@@ -481,20 +483,26 @@ def register():
 	bpy.types.VIEW3D_MT_view_align.append(VIEW3D_MT_view_align.menu)
 	VIEW3D_MT_view_align_selected.register()
 	bpy.types.VIEW3D_MT_view_align_selected.append(VIEW3D_MT_view_align_selected.menu)
-	#VIEW3D_PT_imapaint_tools_missing.register()#クラスなしのためregister()は未定義
+	VIEW3D_PT_addon_sidebar.register()#menuなし
+	#===　廃止したもの　===
+	#VIEW3D_PT_imapaint_tools_missing.register()
 	#bpy.types.VIEW3D_PT_imapaint_tools_missing.append(VIEW3D_PT_imapaint_tools_missing.menu)
 	#VIEW3D_PT_slots_projectpaint.register()
 	#bpy.types.VIEW3D_PT_slots_projectpaint.append(VIEW3D_PT_slots_projectpaint.menu)
+	#=========
 	VIEW3D_PT_tools_imagepaint_external.register()
 	bpy.types.IMAGE_MT_image.append(VIEW3D_PT_tools_imagepaint_external.menu)
-	#VIEW3D_PT_transform_orientations.register()#クラスなしのためregister()は未定義
-	bpy.types.VIEW3D_PT_transform_orientations.append(VIEW3D_PT_transform_orientations.menu)
-	#VIEW3D_PT_view3d_cursor.register()#クラスなしのためregister()は未定義
-	bpy.types.VIEW3D_PT_view3d_cursor.append(VIEW3D_PT_view3d_cursor.menu)
-	#VIEW3D_PT_view3d_name.register()#クラスなしのためregister()は未定義
-	#bpy.types.VIEW3D_PT_view3d_name.append(VIEW3D_PT_view3d_name.menu)
+	#=== VIEW3D_PT_addon_sidebarの中で使用するのでここではメニューを登録しない ===
+	VIEW3D_PT_layers.register()#menuなし
+	#VIEW3D_PT_transform_orientations.register()#クラスなし
+	#bpy.types.VIEW3D_PT_transform_orientations.append(VIEW3D_PT_transform_orientations.menu)
+	#VIEW3D_PT_view3d_cursor.register()#クラスなし
+	#bpy.types.VIEW3D_PT_view3d_cursor.append(VIEW3D_PT_view3d_cursor.menu)
+	#VIEW3D_PT_view3d_name.register()#クラスなし
+	#bpy.types.VIEW3D_PT_tools_object_options.append(VIEW3D_PT_view3d_name.menu)
 	VIEW3D_PT_view3d_properties.register()
-	bpy.types.VIEW3D_PT_view3d_properties.append(VIEW3D_PT_view3d_properties.menu)
+	#bpy.types.VIEW3D_PT_view3d_properties.append(VIEW3D_PT_view3d_properties.menu)
+	#========
 	DATA_PT_shape_curve.register()
 	bpy.types.DATA_PT_shape_curve.append(DATA_PT_shape_curve.menu)
 	BONE_PT_constraints.register()
@@ -665,20 +673,25 @@ def unregister():
 	bpy.types.VIEW3D_MT_view_align.remove(VIEW3D_MT_view_align.menu)
 	VIEW3D_MT_view_align_selected.unregister()
 	bpy.types.VIEW3D_MT_view_align_selected.remove(VIEW3D_MT_view_align_selected.menu)
-	#VIEW3D_PT_imapaint_tools_missing.unregister()#クラスなしのためunregister()は未定義
+	VIEW3D_PT_addon_sidebar.unregister()#menuなし
+	#===　廃止したもの　===
+	#VIEW3D_PT_imapaint_tools_missing.unregister()
 	#bpy.types.VIEW3D_PT_imapaint_tools_missing.remove(VIEW3D_PT_imapaint_tools_missing.menu)
 	#VIEW3D_PT_slots_projectpaint.unregister()
 	#bpy.types.VIEW3D_PT_slots_projectpaint.remove(VIEW3D_PT_slots_projectpaint.menu)
+	#========
 	VIEW3D_PT_tools_imagepaint_external.unregister()
 	bpy.types.IMAGE_MT_image.remove(VIEW3D_PT_tools_imagepaint_external.menu)
-	#VIEW3D_PT_transform_orientations.unregister()#クラスなしのためunregister()は未定義
-	bpy.types.VIEW3D_PT_transform_orientations.remove(VIEW3D_PT_transform_orientations.menu)
-	#VIEW3D_PT_view3d_cursor.unregister()#クラスなしのためunregister()は未定義
-	bpy.types.VIEW3D_PT_view3d_cursor.remove(VIEW3D_PT_view3d_cursor.menu)
-	#VIEW3D_PT_view3d_name.unregister()#クラスなしのためunregister()は未定義
-	#bpy.types.VIEW3D_PT_view3d_name.remove(VIEW3D_PT_view3d_name.menu)
+	#=== VIEW3D_PT_addon_sidebarの中で使用するのでここではメニューを登録解除しない ===
+	VIEW3D_PT_layers.unregister()#menuなし
+	#bpy.types.VIEW3D_PT_transform_orientations.remove(VIEW3D_PT_transform_orientations.menu)
+	#VIEW3D_PT_view3d_cursor.unregister()#クラスなし
+	#bpy.types.VIEW3D_PT_view3d_cursor.remove(VIEW3D_PT_view3d_cursor.menu)
+	#VIEW3D_PT_view3d_name.unregister()#クラスなし
+	#bpy.types.VIEW3D_PT_tools_object_options.remove(VIEW3D_PT_view3d_name.menu)
 	VIEW3D_PT_view3d_properties.unregister()
-	bpy.types.VIEW3D_PT_view3d_properties.remove(VIEW3D_PT_view3d_properties.menu)
+	#bpy.types.VIEW3D_PT_view3d_properties.remove(VIEW3D_PT_view3d_properties.menu)
+	#========
 	DATA_PT_shape_curve.unregister()
 	bpy.types.DATA_PT_shape_curve.remove(DATA_PT_shape_curve.menu)
 	BONE_PT_constraints.unregister()


### PR DESCRIPTION
※VIEW3Dは数が多いので半分づつプルリクします　

3Dビュー画面でのコンテキストメニューおよび通常メニューについて、機能の修正・動作確認を行いました。
Addonの機能の説明のうち、一番上から「3Dビュー」エリア > 「ポーズ」モード > 「W」キーの部分までは、前回の例外部分を除き記述通りに機能します。　

◯各モジュールの変更点　
**VIEW3D_MT_armature_specials**：　
　・bone_R や bone_L といった名前付け機能：強制　→　任意実行　
　・ミラーリングした「根っこ」部分のボーンにおいて、ミラー元の接続先を引き継ぐオプションを追加　
　・「反対位置にあるボーンをリネーム」機能における bone_R などの名前付け：　
　　　強制　→　参照元が接尾語を保たない場合のみ　
　・同機能において、.001 などの不要な番号を消去するオプションを追加　
　

**VIEW3D_MT_bone_options_toggle**：　
　・変更するデータ：常にポーズボーンのデータ　→　編集モードではエディットボーンのデータ　
　

**VIEW3D_MT_edit_mesh**：　
　○プロポーショナル変形の仕様変更に合わせ、パイメニューを変更　
　・メニュー呼び出し時の動作：有効無効の切り替え　→　なにもしない　
　・パイメニューに無効化を追加　
　※2.7以前では「投影」と「接続のみ」は排他的であったが、2.8では併用可能なのでそちらに合わせている　
　　→パイメニューの扱い方を考えれば排他的にしたほうが良いかも？　(投影を使わないのでどちらが便利かわからない)　
　

**VIEW3D_MT_edit_mesh_showhide**：　
　・通常の頂点データでは選択状態がうまく更新されないので、bmeshに変更　
　・選択していないオブジェクトを隠したあとの選択状態：なにも選択しない　→　隠す前の状態に復帰　
　

**VIEW3D_MT_edit_mesh_specials**：　
　・頂点カラーのデータを持たない場合：何もしない　→　新規データを作り、それを操作　
　・頂点グループのデータを持たない場合：何もしない　→　エラーメッセージを表示　
　

**VIEW3D_MT_object** ：　
　・サブモジュール読み込み方法の変更の影響で他のモジュールのクラスが呼び出せないので、サブモジュールを明示的に import する形式に修正　
　

**VIEW3D_MT_make_links**：　
　・レイヤー移動機能をコレクション移動機能に変更　
　・「ポーズをコピーしたアーマチュア追加」機能において、影響力を設定するオプションを追加　
　

**VIEW3D_MT_object_showhide**：　
　○機能全体において、表示切り替えの対象を「オブジェクト」と「オブジェクト+コレクション」で選択するオプションを追加
　・子コレクションの表示を切り替える機能と別個に、親コレクションごと切り替える機能を新規に追加
　

**VIEW3D_MT_object_specials**：　
　○「グリースペンシルにメタボール配置」機能：　
　　◆現状ではアノテーションに対しては実行できないで、今後対応　
　○「レンダリングするかを「表示/非表示」に同期」機能：　
　　・コレクションの表示状態も考慮するオプションを追加　
　○非選択物の選択を制限：　
　　・ボタン有効化条件を簡単化　
　　・非表示のコレクション内部のオブジェクトを除外するオプションを追加　
　○オブジェクトカラー関係の機能：　
　　◆機能が削除されたと勘違いしていたが、利用方法が変更されただけだったので今後対応　
　○「モディファイア適用してペアレント作成」機能：　
　　◆機能の意図がわからないので、エラーを潰しただけ
　○「カーブからロープ状のメッシュを作成」機能：　
　　・作成したメッシュの原点：ワールド　→　メッシュの中心
　○「ベベルオブジェクトを断面に移動」機能　
　　・機能実行後の選択オブジェクト：元のもの　→　移動したベベルオブジェクト(カーブ)　
　

**VIEW3D_MT_paint_weight**：　
　・ウエイトの加算と減算において対象のボーンをメニューから選択する機能を追加　
　※ウエイトペイントしながらこの機能を使いたい場合、ボーンの追加選択が難しいのでその代替　
　※※スクリプトを通すとダイナミックペイントの結果が保存されないバグ？があるので、とりあえずソフトボディを挟んで対処
　　→　頂点グループへの参照さえあれば良いので、もっと軽いコンストレイントにするべきかもしれない
　

**VIEW3D_MT_pose_constraints**：　
　・IK制限のコピー時に、コピー元の制限を解除するオプションを追加
　

**VIEW3D_MT_pose_specials**：　
　○「チェーン状ボーンをグリースペンシルに沿わせる」機能：　
　　・グリースペンシルを選択する機能を追加　
　　◆現状ではアノテーションに対しては実行できないで、今後対応　
　○「スローペアレントを設定」機能：　
　　・スローペアレント機能が削除されたので、ドライバーで代替　
　○「現ポーズを回転制限にする」機能：　
　　・回転していない側の制限を0にするオプションを追加　
　　・小数点第二位以下は丸める処理を追加　
　　・従来の「反転しない」オプションを「180度に制限する」オプションとして明示的に処理　
　　・オプションの選び方：チェックボックス　→　ドロップダウンリスト　
　
